### PR TITLE
Use better inlining of JS

### DIFF
--- a/templates/partials/owl-carousel.html.twig
+++ b/templates/partials/owl-carousel.html.twig
@@ -2,13 +2,9 @@
 <div class="owl-carousel owl-theme" id="{{ owl_id }}">
     {{ owl_items|regex_replace('(^\n?<p>|<\/p>$)','') }}
 </div>
-<script>
-    $(document).ready(function(){
-        $("#{{ owl_id }}").owlCarousel({
-            {% for name,param in params %}
-            {{ name }}: {{ param }},
-            {% endfor %}
-        });
-    });
-</script>
-
+{%  set owl_options = '' %}
+{%  for name,param in params %}
+    {% set owl_options = owl_options ~ name ~ ':' ~ param ~',' %}
+{% endfor %}
+{% do assets.addInlineJs(' $(document).ready(function(){ $("#' ~
+owl_id ~ '").owlCarousel({' ~ owl_options ~ '}); }); ') %}


### PR DESCRIPTION
This puts the calling code behind the asset js call. Should ensure that the dependencies are set before. Then, we can move scripts to the bottom.