### PR TITLE
set custom css prio to 5

### DIFF
--- a/shortcodes/OwlCarouselShortcode.php
+++ b/shortcodes/OwlCarouselShortcode.php
@@ -22,7 +22,7 @@ class OwlCarouselShortcode extends Shortcode
             }
             // load built-in-css
             if ($this->config->get('plugins.shortcode-owl-carousel.built_in_css', false)) {
-                $this->shortcode->addAssets('css', 'plugin://shortcode-owl-carousel/css/shortcode.owl.carousel.css');
+                $this->shortcode->addAssets('css', ['plugin://shortcode-owl-carousel/css/shortcode.owl.carousel.css', 5]);
             }
 
             $hash = $this->shortcode->getId($sc);


### PR DESCRIPTION
set custom css prio to 5 to make sure the external classes are loaded last.
As discussed in issue #8 this seems to be not consistent in different env.

maybe this can be considered as a workaround.