### PR TITLE
#8 add explicit prio to css

### DIFF
--- a/shortcodes/OwlCarouselShortcode.php
+++ b/shortcodes/OwlCarouselShortcode.php
@@ -14,15 +14,15 @@ class OwlCarouselShortcode extends Shortcode
             // Add assets
             $this->shortcode->addAssets('js', ['jquery', 101]);
             $this->shortcode->addAssets('js', 'plugin://shortcode-owl-carousel/js/owl.carousel.min.js');
-            $this->shortcode->addAssets('css', 'plugin://shortcode-owl-carousel/css/owl.carousel.min.css');
-            $this->shortcode->addAssets('css', 'plugin://shortcode-owl-carousel/css/owl.theme.default.min.css');
+            $this->shortcode->addAssets('css', ['plugin://shortcode-owl-carousel/css/owl.carousel.min.css', 9]);
+            $this->shortcode->addAssets('css', ['plugin://shortcode-owl-carousel/css/owl.theme.default.min.css', 8]);
             // load animate.css if required
             if ($sc->getParameter('animate') == 'true') {
                 $this->shortcode->addAssets('css', 'plugin://shortcode-owl-carousel/css/animate.css');
             }
             // load built-in-css
             if ($this->config->get('plugins.shortcode-owl-carousel.built_in_css', false)) {
-                $this->shortcode->addAssets('css', ['plugin://shortcode-owl-carousel/css/shortcode.owl.carousel.css', 5]);
+                $this->shortcode->addAssets('css', ['plugin://shortcode-owl-carousel/css/shortcode.owl.carousel.css', 7]);
             }
 
             $hash = $this->shortcode->getId($sc);

--- a/shortcodes/OwlCarouselShortcode.php
+++ b/shortcodes/OwlCarouselShortcode.php
@@ -22,7 +22,7 @@ class OwlCarouselShortcode extends Shortcode
             }
             // load built-in-css
             if ($this->config->get('plugins.shortcode-owl-carousel.built_in_css', false)) {
-                $this->shortcode->addAssets('css', 'plugin://shortcode-owl-carousel/css/shortcode.owl.carousel.css');
+                $this->shortcode->addAssets('css', ['plugin://shortcode-owl-carousel/css/shortcode.owl.carousel.css', 5]);
             }
 
             $hash = $this->shortcode->getId($sc);


### PR DESCRIPTION
As discussed in #8 there is something strange how the css files are loaded.
Somehow it has something to do with localhost vs. prod-env,
Somehow if when the plugin is used more than once on the same (modular) page.
Explicit defining the prio of all css sources solves the problem.