### PR TITLE
fix: match type for parameter values

### DIFF
--- a/shortcodes/OwlCarouselShortcode.php
+++ b/shortcodes/OwlCarouselShortcode.php
@@ -12,12 +12,30 @@ class OwlCarouselShortcode extends Shortcode
 
             $id = 'owl-' . $this->shortcode->getId($sc);
 
+            // fix type of parameters value for json_encode
+            $params = $sc->getParameters();
+            foreach ($params as $key => $value) {
+                if ($key === "responsive") {
+                    // value is json not string
+                    $value = preg_replace('/(\w+)/','"$1"',$value);
+                    $value = preg_replace('/"(true|false)"/','$1',$value);
+                    $params[$key] = json_decode($value,true);
+                } else {
+                    // value is boolean or string
+                    if ($value === "true") {
+                        $params[$key] = true;
+                    } elseif ($value === "false") {
+                        $params[$key] = false;
+                    } // else: keep value as string
+                }
+            }
+
             // Add assets
             $this->shortcode->addAssets('js', ['jquery', 101]);
             $this->shortcode->addAssets('js', 'plugin://shortcode-owl-carousel/js/owl.carousel.min.js');
             $this->shortcode->addAssets('css', 'plugin://shortcode-owl-carousel/css/owl.carousel.min.css');
             $this->shortcode->addAssets('css', 'plugin://shortcode-owl-carousel/css/owl.theme.default.min.css');
-            $this->shortcode->addAssets('inlinejs', '$(document).ready(function(){ $("#' . $id . '").owlCarousel(' . json_encode($sc->getParameters(), JSON_NUMERIC_CHECK) . '); }); ');
+            $this->shortcode->addAssets('inlinejs', '$(document).ready(function(){ $("#' . $id . '").owlCarousel(' . json_encode($params, JSON_NUMERIC_CHECK) . '); }); ');
 
             // load animate.css if required
             if ($sc->getParameter('animate') == 'true') {


### PR DESCRIPTION
This fixes the broken responsive parameter (issue #2) and boolean values handling introduced in v1.0.2

Details:
- responsive value is json not string (issue #2)
- "true"/"false" must be boolean not string

Testcode:
```
[owl-carousel margin=10 loop=false autoplay=false autoplayHoverPause=true nav=false responsive="{0:{items:1,autoplay:true},600:{items:2},1000:{items:3,loop:true}}"]
![](pic_1.jpg)
...
[/owl-carousel]
```
Output v1.0.1:
```javascript
        $("#owl-0ce80006b3").owlCarousel({
                        margin: 10,
                        loop: false,
                        autoplay: false,
                        autoplayHoverPause: true,
                        nav: false,
                        responsive: {0:{items:1,autoplay:true},600:{items:2},1000:{items:3,loop:true}},
                    });
```

Output v1.0.2:
```javascript
$(document).ready(function(){ $("#owl-0ce80006b3").owlCarousel({"margin":10,"loop":"false","autoplay":"false","autoplayHoverPause":"true","nav":"false","responsive":"{0:{items:1,autoplay:true},600:{items:2},1000:{items:3,loop:true}}"}); });
```
json_encode quotes everything except numbers as a string. Therefore in owlCarousel:
"true"/"false" gets ignored - defaults are used
"responsive" value as string causes an TypeError in jQuery - the owl-carousel is not shown

Output this version:
```javascript
$(document).ready(function(){ $("#owl-0ce80006b3").owlCarousel({"margin":10,"loop":false,"autoplay":false,"autoplayHoverPause":true,"nav":false,"responsive":{"0":{"items":1,"autoplay":true},"600":{"items":2},"1000":{"items":3,"loop":true}}}); });
```
works again.
