### PR TITLE
Modify document ready method

### DIFF
--- a/shortcodes/OwlCarouselShortcode.php
+++ b/shortcodes/OwlCarouselShortcode.php
@@ -35,7 +35,7 @@ class OwlCarouselShortcode extends Shortcode
             $this->shortcode->addAssets('js', 'plugin://shortcode-owl-carousel/js/owl.carousel.min.js');
             $this->shortcode->addAssets('css', 'plugin://shortcode-owl-carousel/css/owl.carousel.min.css');
             $this->shortcode->addAssets('css', 'plugin://shortcode-owl-carousel/css/owl.theme.default.min.css');
-            $this->shortcode->addAssets('inlinejs', '$(document).ready(function(){ $("#' . $id . '").owlCarousel(' . json_encode($params, JSON_NUMERIC_CHECK) . '); }); ');
+            $this->shortcode->addAssets('inlinejs', '$(window).on("load", function(){ $("#' . $id . '").owlCarousel(' . json_encode($params, JSON_NUMERIC_CHECK) . '); }); ');
 
             // load animate.css if required
             if ($sc->getParameter('animate') == 'true') {


### PR DESCRIPTION
The old document ready function causes the carousel to break when using autoWidth=true and doing a cache refresh or visiting a site for the first time. Modified to window load function so that the images have chance to load before executing the code.